### PR TITLE
feat: Add GitHub Actions workflow to publish Docker image to GHCR

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,30 @@
+name: Publish Docker image to GHCR
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./base/main
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}


### PR DESCRIPTION
This workflow builds the Docker image from ./base/main/Dockerfile and pushes it to GitHub Container Registry on every push to any branch. The image is tagged with the Git commit SHA.